### PR TITLE
feat: 修改`.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,8 +61,8 @@ VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 ## Github OAuth
 GITHUB_CLIENT_ID=GitHub_Client_ID
 GITHUB_CLIENT_SECRET=GitHub_Client_secrets
-GITHUB_REDIREC=GitHub_Authorization_callback_URL
+GITHUB_REDIRECT=GitHub_Authorization_callback_URL
 ## Facebook OAuth
-FACEBOOK_CLIENT_ID=GitHub_Client_ID
-FACEBOOK_CLIENT_SECRET=GitHub_Client_secrets
-FACEBOOK_REDIRECT_URI=GitHub_Authorization_callback_URL
+FACEBOOK_CLIENT_ID=Facebook_Client_ID
+FACEBOOK_CLIENT_SECRET=Facebook_Client_secrets
+FACEBOOK_REDIRECT_URI=Facebook_Authorization_callback_URL


### PR DESCRIPTION
- 專案上傳至雲端後, 發現 `.env.example` 存在字誤的情況，此 commit 作為修改 .env
- 本地端: `http://localhost:8084/auth..` 雲端改為: `https://lucaslego.com/auth..`
- 本地端/雲端初始測試 localhost:8084時，用 localhost 就好，誤用 127.0.0.1
   - 雲端測試時， localhost 不等於 127.0.0.1
   - 本機端的 localhost , 127.0.0.1 可以互用, 是因為在 `/etc/hosts` 有設定這兩個 URI 的關係